### PR TITLE
Add GroupMemberUid to search for posix groups as well

### DIFF
--- a/src/UserGroupsRequest/GroupMemberUid.php
+++ b/src/UserGroupsRequest/GroupMemberUid.php
@@ -15,7 +15,7 @@ class GroupMemberUid extends UserGroupsRequest {
 	 */
 	public function getUserGroups( $username ) {
 		$userDN = new EscapedString( $this->ldapClient->getUserDN( $username, 'uid' ) );
-        $userUid = $this->ldapClient->LDAPUsername;
+		$userUid = $this->ldapClient->LDAPUsername;
 		$baseDN = $this->config->get( ClientConfig::GROUP_BASE_DN );
 		$dn = 'dn';
 

--- a/src/UserGroupsRequest/GroupMemberUid.php
+++ b/src/UserGroupsRequest/GroupMemberUid.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MediaWiki\Extension\LDAPProvider\UserGroupsRequest;
+
+use MediaWiki\Extension\LDAPProvider\ClientConfig;
+use MediaWiki\Extension\LDAPProvider\EscapedString;
+use MediaWiki\Extension\LDAPProvider\GroupList;
+use MediaWiki\Extension\LDAPProvider\UserGroupsRequest;
+
+class GroupMemberUid extends UserGroupsRequest {
+
+	/**
+	 * @param string $username to get the groups for
+	 * @return GroupList
+	 */
+	public function getUserGroups( $username ) {
+		$userDN = new EscapedString( $this->ldapClient->getUserDN( $username, 'uid' ) );
+        $userUid = $this->ldapClient->LDAPUsername;
+		$baseDN = $this->config->get( ClientConfig::GROUP_BASE_DN );
+		$dn = 'dn';
+
+		if ( $baseDN === '' ) {
+			$baseDN = null;
+		}
+		if ( $this->config->get( ClientConfig::NESTED_GROUPS ) ) {
+			$groups = $this->ldapClient->search(
+				"(memberUid:1.2.840.113556.1.4.1941:=$userUid)",
+				$baseDN, [ $dn ]
+			);
+		} else {
+			$groups = $this->ldapClient->search(
+				"(&(objectclass=posixGroup)(memberUid=$userUid))",
+				$baseDN, [ $dn ]
+			);
+		}
+		$ret = [];
+		foreach ( $groups as $key => $value ) {
+			if ( is_int( $key ) ) {
+				$ret[] = $value[$dn];
+			}
+		}
+		return new GroupList( $ret );
+	}
+
+}


### PR DESCRIPTION
Add GroupMemberUid as copy of GroupMember to search for PosixGroups as discussed at https://www.mediawiki.org/wiki/Topic:Vcpn9bycm7fyyq23 and https://phabricator.wikimedia.org/T240750

Please consider adding this to the default Group search possibilities to support OpenLDAP servers out of the box as well.